### PR TITLE
[WOLF-3] Ajout du support des images dans Notion2Latex 🖼️

### DIFF
--- a/wolf/main.py
+++ b/wolf/main.py
@@ -1,14 +1,21 @@
 import os
-
+import sys
 from wolf_core import runner
 
 # Import all the modules you want to be runnable here
 if __name__ == "__main__":
-    # for all files in the modules folder, import them
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "debug":
+            debug = True
+        else:
+            debug = False
+    else:
+        debug = False
+
     abs_path = os.path.dirname(os.path.abspath(__file__))
     for file in os.listdir(abs_path):
         if file.endswith(".py") and file not in ["main.py", "install.py", "__init__.py"]:
             __import__(f"wolf.{file[:-3]}")
 
-    main_runner = runner.Runner(debug=False)
+    main_runner = runner.Runner(debug=debug)
     main_runner.run()

--- a/wolf/notion_latex.py
+++ b/wolf/notion_latex.py
@@ -146,6 +146,11 @@ class Notion2Latex(application.Application):
         """
         MarkdownExporter(block_id=file, output_path='.', download=True).export()
         self.run_command("unzip -o -d . " + file + ".zip > /dev/null")
+        self.run_command("mv *.png doc_latex-template-complex-version/src")
+        self.run_command("mv *.jpg doc_latex-template-complex-version/src")
+        self.run_command("mv *.jpeg doc_latex-template-complex-version/src")
+        self.run_command("mv *.svg doc_latex-template-complex-version/src")
+        self.run_command("mv *.gif doc_latex-template-complex-version/src")
         self.run_command("rm " + file + ".zip")
         param_dict = None
         with open(file + ".md") as f:
@@ -232,8 +237,8 @@ class Notion2Latex(application.Application):
             self.logger.info("No diff between {} and {}".format(file_path_tex, last_compiled_path_tex))
             return False, title
 
-        success_first = self.run_command("xelatex " + file + ".tex interaction=nonstopmode >/dev/null")
-        success_second = self.run_command("xelatex " + file + ".tex interaction=nonstopmode >/dev/null")
+        success_first = self.run_command("xelatex -interaction=nonstopmode " + file + ".tex  >/dev/null")
+        success_second = self.run_command("xelatex -interaction=nonstopmode " + file + ".tex  >/dev/null")
         success = success_first and success_second
         if not success:
             self.logger.error("Failed to compile file: " + file + ".md")


### PR DESCRIPTION
🎟️ Introduction

Dans ce Pull Request, une mise à jour est apportée à l'outil Notion2Latex. En réponse à l'issue [WOLF-3], cette mise à jour permet à maintenant de prendre en charge les images lors de la conversion des données de Notion vers le format LaTeX.

📋 Détails

La fonctionnalité a été mise en œuvre de la manière suivante :
- Notion2Latex a été mis à jour pour inclure les images lors de la conversion des données.
- Au lieu de créer un lien vers une image, l'image est intégrée directement dans le document converti 🖼️.
